### PR TITLE
Update to plot_confusion_matrix (figsize argument and to work if Seaborn is used)

### DIFF
--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -54,7 +54,7 @@ def classifier_factory(clf):
 
 
 def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv=None,
-                          shuffle=True, random_state=None, ax=None, figsize=6):
+                          shuffle=True, random_state=None, ax=None, figsize=6, title_fontsize="large", text_fontsize="medium"):
     """Generates the confusion matrix for a given classifier and dataset.
 
     Args:
@@ -102,6 +102,13 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
 
         figsize (int, optional): Rectangular figure size of the plot. Defaults to 6.
 
+        title_fontsize (string or int, optional): Matplotlib-style fontsizes. 
+            Use e.g. "small", "medium", "large" or integer-values. Defaults to "large".
+
+        text_fontsize (string or int, optional): Matplotlib-style fontsizes. 
+            Use e.g. "small", "medium", "large" or integer-values. Defaults to "medium".
+
+
     Returns:
         ax (:class:`matplotlib.axes.Axes`): The axes on which the plot was drawn.
 
@@ -144,7 +151,8 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
         y_true = np.concatenate(trues_list)
 
     ax = plotters.plot_confusion_matrix(y_true=y_true, y_pred=y_pred,
-                                        title=title, normalize=normalize, ax=ax, figsize=figsize)
+                                        title=title, normalize=normalize, ax=ax, figsize=figsize, 
+                                        title_fontsize=title_fontsize, text_fontsize=text_fontsize)
 
     return ax
 

--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -54,7 +54,7 @@ def classifier_factory(clf):
 
 
 def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv=None,
-                          shuffle=True, random_state=None, ax=None):
+                          shuffle=True, random_state=None, ax=None, figsize=6):
     """Generates the confusion matrix for a given classifier and dataset.
 
     Args:
@@ -100,6 +100,8 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
         ax (:class:`matplotlib.axes.Axes`, optional): The axes upon which to plot
             the learning curve. If None, the plot is drawn on a new set of axes.
 
+        figsize (int, optional): Rectangular figure size of the plot. Defaults to 6.
+
     Returns:
         ax (:class:`matplotlib.axes.Axes`): The axes on which the plot was drawn.
 
@@ -142,7 +144,7 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
         y_true = np.concatenate(trues_list)
 
     ax = plotters.plot_confusion_matrix(y_true=y_true, y_pred=y_pred,
-                                        title=title, normalize=normalize, ax=ax)
+                                        title=title, normalize=normalize, ax=ax, figsize=figsize)
 
     return ax
 

--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -54,7 +54,8 @@ def classifier_factory(clf):
 
 
 def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv=None,
-                          shuffle=True, random_state=None, ax=None, figsize=6, title_fontsize="large", text_fontsize="medium"):
+                          shuffle=True, random_state=None, ax=None, figsize=None, 
+                          title_fontsize="large", text_fontsize="medium"):
     """Generates the confusion matrix for a given classifier and dataset.
 
     Args:
@@ -100,7 +101,8 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
         ax (:class:`matplotlib.axes.Axes`, optional): The axes upon which to plot
             the learning curve. If None, the plot is drawn on a new set of axes.
 
-        figsize (int, optional): Rectangular figure size of the plot. Defaults to 6.
+        figsize (2-tuple, optional): Tuple denoting figure size of the plot e.g. (6, 6). 
+            Defaults to ``None``.
 
         title_fontsize (string or int, optional): Matplotlib-style fontsizes. 
             Use e.g. "small", "medium", "large" or integer-values. Defaults to "large".

--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -22,7 +22,7 @@ from sklearn.metrics import silhouette_samples
 from scipy.spatial.distance import cdist, pdist
 
 
-def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, figsize=6):
+def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, figsize=6, title_fontsize="large", text_fontsize="medium"):
     """Generates confusion matrix plot for a given set of ground truth labels and classifier predictions.
 
     Args:
@@ -43,6 +43,12 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, 
 
         figsize (int, optional): Rectangular figure size of the plot. Defaults to 6.
 
+        title_fontsize (string or int, optional): Matplotlib-style fontsizes. 
+            Use e.g. "small", "medium", "large" or integer-values. Defaults to "large".
+
+        text_fontsize (string or int, optional): Matplotlib-style fontsizes. 
+            Use e.g. "small", "medium", "large" or integer-values. Defaults to "medium".
+            
     Returns:
         ax (:class:`matplotlib.axes.Axes`): The axes on which the plot was drawn.
 
@@ -70,31 +76,30 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, 
         cm = np.around(cm, decimals=2)
 
     if title:
-        ax.set_title(title, fontsize=figsize*2.5)
+        ax.set_title(title, fontsize=title_fontsize)
     elif normalize:
-        ax.set_title('Normalized Confusion Matrix', fontsize=figsize*2.5)
+        ax.set_title('Normalized Confusion Matrix', fontsize=title_fontsize)
     else:
-        ax.set_title('Confusion Matrix', fontsize=figsize*2.5)
+        ax.set_title('Confusion Matrix', fontsize=title_fontsize)
 
     image = ax.imshow(cm, interpolation='nearest', cmap=plt.cm.Blues)
     plt.colorbar(mappable=image)
     tick_marks = np.arange(len(classes))
     ax.set_xticks(tick_marks)
-    ax.set_xticklabels(classes, fontsize=figsize*2)
+    ax.set_xticklabels(classes, fontsize=text_fontsize)
     ax.set_yticks(tick_marks)
-    ax.set_yticklabels(classes, fontsize=figsize*2)
+    ax.set_yticklabels(classes, fontsize=text_fontsize)
 
     thresh = cm.max() / 2.
     for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
         ax.text(j, i, cm[i, j],
                 horizontalalignment="center",
                 verticalalignment="center",
-                fontsize=figsize*2,
-                bbox={'facecolor':'silver', 'alpha':0.8, 'pad':figsize},
-                color="black")
+                fontsize=text_fontsize,
+                color="white" if cm[i, j] > thresh else "black")
 
-    ax.set_ylabel('True label', fontsize=figsize*2)
-    ax.set_xlabel('Predicted label', fontsize=figsize*2)
+    ax.set_ylabel('True label', fontsize=text_fontsize)
+    ax.set_xlabel('Predicted label', fontsize=text_fontsize)
 
     return ax
 

--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -22,7 +22,7 @@ from sklearn.metrics import silhouette_samples
 from scipy.spatial.distance import cdist, pdist
 
 
-def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None):
+def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, figsize=6):
     """Generates confusion matrix plot for a given set of ground truth labels and classifier predictions.
 
     Args:
@@ -41,6 +41,8 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None):
         ax (:class:`matplotlib.axes.Axes`, optional): The axes upon which to plot
             the learning curve. If None, the plot is drawn on a new set of axes.
 
+        figsize (int, optional): Rectangular figure size of the plot. Defaults to 6.
+
     Returns:
         ax (:class:`matplotlib.axes.Axes`): The axes on which the plot was drawn.
 
@@ -58,7 +60,7 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None):
            :alt: Confusion matrix
     """
     if ax is None:
-        fig, ax = plt.subplots(1, 1)
+        fig, ax = plt.subplots(1, 1, figsize=(figsize,figsize))
 
     cm = confusion_matrix(y_true, y_pred)
     classes = np.unique(y_true)
@@ -68,31 +70,33 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None):
         cm = np.around(cm, decimals=2)
 
     if title:
-        ax.set_title(title)
+        ax.set_title(title, fontsize=figsize*2.5)
     elif normalize:
-        ax.set_title('Normalized Confusion Matrix')
+        ax.set_title('Normalized Confusion Matrix', fontsize=figsize*2.5)
     else:
-        ax.set_title('Confusion Matrix')
+        ax.set_title('Confusion Matrix', fontsize=figsize*2.5)
 
     image = ax.imshow(cm, interpolation='nearest', cmap=plt.cm.Blues)
     plt.colorbar(mappable=image)
     tick_marks = np.arange(len(classes))
     ax.set_xticks(tick_marks)
-    ax.set_xticklabels(classes)
+    ax.set_xticklabels(classes, fontsize=figsize*2)
     ax.set_yticks(tick_marks)
-    ax.set_yticklabels(classes)
+    ax.set_yticklabels(classes, fontsize=figsize*2)
 
     thresh = cm.max() / 2.
     for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
         ax.text(j, i, cm[i, j],
                 horizontalalignment="center",
-                color="white" if cm[i, j] > thresh else "black")
+                verticalalignment="center",
+                fontsize=figsize*2,
+                bbox={'facecolor':'silver', 'alpha':0.8, 'pad':figsize},
+                color="black")
 
-    ax.set_ylabel('True label')
-    ax.set_xlabel('Predicted label')
+    ax.set_ylabel('True label', fontsize=figsize*2)
+    ax.set_xlabel('Predicted label', fontsize=figsize*2)
 
     return ax
-
 
 def plot_roc_curve(y_true, y_probas, title='ROC Curves', ax=None):
     """Generates the ROC curves for a set of ground truth labels and classifier probability predictions.

--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -22,7 +22,8 @@ from sklearn.metrics import silhouette_samples
 from scipy.spatial.distance import cdist, pdist
 
 
-def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, figsize=6, title_fontsize="large", text_fontsize="medium"):
+def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, figsize=None, 
+                          title_fontsize="large", text_fontsize="medium"):
     """Generates confusion matrix plot for a given set of ground truth labels and classifier predictions.
 
     Args:
@@ -41,7 +42,8 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, 
         ax (:class:`matplotlib.axes.Axes`, optional): The axes upon which to plot
             the learning curve. If None, the plot is drawn on a new set of axes.
 
-        figsize (int, optional): Rectangular figure size of the plot. Defaults to 6.
+        figsize (2-tuple, optional): Tuple denoting figure size of the plot e.g. (6, 6). 
+            Defaults to ``None``.
 
         title_fontsize (string or int, optional): Matplotlib-style fontsizes. 
             Use e.g. "small", "medium", "large" or integer-values. Defaults to "large".
@@ -66,7 +68,7 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, 
            :alt: Confusion matrix
     """
     if ax is None:
-        fig, ax = plt.subplots(1, 1, figsize=(figsize,figsize))
+        fig, ax = plt.subplots(1, 1, figsize=figsize)
 
     cm = confusion_matrix(y_true, y_pred)
     classes = np.unique(y_true)


### PR DESCRIPTION
Using the confusion matrix in a jupyter notebook returns a plot that is quite small. If Seaborn is also used, some values in the plot are hard to read (white text on white lines).

I have added a figsize-argument to the plot_confusion_matrix and changed the way that values are displayed (now with neutral background box). For larger plots all text-elements scale with the figsize-argument.