### PR TITLE
Add new argument `labels` to plot_confusion_matrix. 

### DIFF
--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -53,7 +53,7 @@ def classifier_factory(clf):
     return clf
 
 
-def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv=None,
+def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, do_cv=True, cv=None,
                           shuffle=True, random_state=None, ax=None, figsize=None, 
                           title_fontsize="large", text_fontsize="medium"):
     """Generates the confusion matrix for a given classifier and dataset.
@@ -67,6 +67,11 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
 
         y (array-like, shape (n_samples) or (n_samples, n_features)):
             Target relative to X for classification.
+
+        labels (array-like, shape (n_classes), optional): List of labels to
+            index the matrix. This may be used to reorder or select a subset of labels.
+            If none is given, those that appear at least once in ``y`` are used in sorted order.
+            (new in v0.2.5)
 
         title (string, optional): Title of the generated plot. Defaults to "Confusion Matrix" if
             `normalize` is True. Else, defaults to "Normalized Confusion Matrix.
@@ -152,7 +157,7 @@ def plot_confusion_matrix(clf, X, y, title=None, normalize=False, do_cv=True, cv
         y_pred = np.concatenate(preds_list)
         y_true = np.concatenate(trues_list)
 
-    ax = plotters.plot_confusion_matrix(y_true=y_true, y_pred=y_pred,
+    ax = plotters.plot_confusion_matrix(y_true=y_true, y_pred=y_pred, labels=labels,
                                         title=title, normalize=normalize, ax=ax, figsize=figsize, 
                                         title_fontsize=title_fontsize, text_fontsize=text_fontsize)
 

--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -12,6 +12,7 @@ from sklearn.metrics import roc_curve
 from sklearn.metrics import auc
 from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import average_precision_score
+from sklearn.utils.multiclass import unique_labels
 from sklearn.model_selection import learning_curve
 from scipy import interp
 import itertools
@@ -21,8 +22,8 @@ from sklearn.metrics import silhouette_score
 from sklearn.metrics import silhouette_samples
 
 
-def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, figsize=None, 
-                          title_fontsize="large", text_fontsize="medium"):
+def plot_confusion_matrix(y_true, y_pred, labels=None, title=None, normalize=False, ax=None,
+                          figsize=None, title_fontsize="large", text_fontsize="medium"):
     """Generates confusion matrix plot for a given set of ground truth labels and classifier predictions.
 
     Args:
@@ -31,6 +32,11 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, 
 
         y_pred (array-like, shape (n_samples)):
             Estimated targets as returned by a classifier.
+
+        labels (array-like, shape (n_classes), optional): List of labels to
+            index the matrix. This may be used to reorder or select a subset of labels.
+            If none is given, those that appear at least once in ``y_true`` or
+            ``y_pred`` are used in sorted order. (new in v0.2.5)
 
         title (string, optional): Title of the generated plot. Defaults to "Confusion Matrix" if
             `normalize` is True. Else, defaults to "Normalized Confusion Matrix.
@@ -69,8 +75,11 @@ def plot_confusion_matrix(y_true, y_pred, title=None, normalize=False, ax=None, 
     if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=figsize)
 
-    cm = confusion_matrix(y_true, y_pred)
-    classes = np.unique(y_true)
+    cm = confusion_matrix(y_true, y_pred, labels=labels)
+    if labels is None:
+        classes = unique_labels(y_true, y_pred)
+    else:
+        classes = np.asarray(labels)
 
     if normalize:
         cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]

--- a/scikitplot/tests/test_classifiers.py
+++ b/scikitplot/tests/test_classifiers.py
@@ -171,6 +171,12 @@ class TestPlotConfusionMatrix(unittest.TestCase):
         ax = clf.plot_confusion_matrix(self.X, self.y, normalize=True)
         ax = clf.plot_confusion_matrix(self.X, self.y, normalize=False)
 
+    def test_labels(self):
+        np.random.seed(0)
+        clf = LogisticRegression()
+        scikitplot.classifier_factory(clf)
+        ax = clf.plot_confusion_matrix(self.X, self.y, labels=[0, 1, 2])
+
     def test_do_cv(self):
         np.random.seed(0)
         clf = LogisticRegression()


### PR DESCRIPTION
This also fixes bug in column and row labeling in the case where test set does not contain all training classes #28 