### PR TITLE
fix bug for non-Numpy array inputs

### DIFF
--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -160,6 +160,8 @@ def plot_roc_curve(y_true, y_probas, title='ROC Curves', curves=('micro', 'macro
            :align: center
            :alt: ROC Curves
     """
+    y_true = np.array(y_true)
+    y_probas = np.array(y_probas)
 
     if 'micro' not in curves and 'macro' not in curves and 'each_class' not in curves:
         raise ValueError('Invalid argument for curves as it only takes "micro", "macro", or "each_class"')
@@ -282,6 +284,9 @@ def plot_ks_statistic(y_true, y_probas, title='KS Statistic Plot', ax=None, figs
            :align: center
            :alt: KS Statistic
     """
+    y_true = np.array(y_true)
+    y_probas = np.array(y_probas)
+
     classes = np.unique(y_true)
     if len(classes) != 2:
         raise ValueError('Cannot calculate KS statistic for data with '
@@ -359,6 +364,9 @@ def plot_precision_recall_curve(y_true, y_probas, title='Precision-Recall Curve'
            :align: center
            :alt: Precision Recall Curve
     """
+    y_true = np.array(y_true)
+    y_probas = np.array(y_probas)
+
     classes = np.unique(y_true)
     probas = y_probas
 

--- a/scikitplot/tests/test_classifiers.py
+++ b/scikitplot/tests/test_classifiers.py
@@ -9,6 +9,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 import numpy as np
 import matplotlib.pyplot as plt
+import scikitplot.plotters as skplt
 
 
 def convert_labels_into_string(y_true):
@@ -201,6 +202,9 @@ class TestPlotConfusionMatrix(unittest.TestCase):
         out_ax = clf.plot_confusion_matrix(self.X, self.y, ax=ax)
         assert ax is out_ax
 
+    def test_array_like(self):
+        ax = skplt.plot_confusion_matrix([0, 1], [1, 0])
+
 
 class TestPlotROCCurve(unittest.TestCase):
     def setUp(self):
@@ -272,6 +276,9 @@ class TestPlotROCCurve(unittest.TestCase):
         self.assertRaises(ValueError, clf.plot_roc_curve, self.X, self.y,
                           curves='zzz')
 
+    def test_array_like(self):
+        ax = skplt.plot_roc_curve([0, 1], [[0.8, 0.2], [0.2, 0.8]])
+
 
 class TestPlotKSStatistic(unittest.TestCase):
     def setUp(self):
@@ -332,6 +339,9 @@ class TestPlotKSStatistic(unittest.TestCase):
         assert ax is not out_ax
         out_ax = clf.plot_ks_statistic(self.X, self.y, ax=ax)
         assert ax is out_ax
+
+    def test_array_like(self):
+        ax = skplt.plot_ks_statistic([0, 1], [[0.8, 0.2], [0.2, 0.8]])
 
 
 class TestPlotPrecisionRecall(unittest.TestCase):
@@ -402,6 +412,9 @@ class TestPlotPrecisionRecall(unittest.TestCase):
         scikitplot.classifier_factory(clf)
         self.assertRaises(ValueError, clf.plot_precision_recall_curve, self.X, self.y,
                           curves='zzz')
+
+    def test_array_like(self):
+        ax = skplt.plot_precision_recall_curve([0, 1], [[0.8, 0.2], [0.2, 0.8]])
 
 
 class TestFeatureImportances(unittest.TestCase):


### PR DESCRIPTION
fix plot_roc_curve, plot_ks_statistic, and plot_precision_recall_curve when passed Python lists instead of Numpy arrays