### PR TITLE
Add hide_zeros param to confusion matrix

### DIFF
--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -53,9 +53,9 @@ def classifier_factory(clf):
     return clf
 
 
-def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, x_tick_rotation=0,
-                          do_cv=True, cv=None, shuffle=True, random_state=None, ax=None, figsize=None,
-                          title_fontsize="large", text_fontsize="medium"):
+def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, hide_zeros=False,
+                          x_tick_rotation=0, do_cv=True, cv=None, shuffle=True, random_state=None,
+                          ax=None, figsize=None, title_fontsize="large", text_fontsize="medium"):
     """Generates the confusion matrix for a given classifier and dataset.
 
     Args:
@@ -77,6 +77,9 @@ def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, x
             `normalize` is True. Else, defaults to "Normalized Confusion Matrix.
 
         normalize (bool, optional): If True, normalizes the confusion matrix before plotting.
+            Defaults to False.
+
+        hide_zeros (bool, optional): If True, does not plot cells containing a value of zero.
             Defaults to False.
 
         x_tick_rotation (int, optional): Rotates x-axis tick labels by the specified angle. This is
@@ -161,7 +164,7 @@ def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, x
         y_true = np.concatenate(trues_list)
 
     ax = plotters.plot_confusion_matrix(y_true=y_true, y_pred=y_pred, labels=labels,
-                                        title=title, normalize=normalize,
+                                        title=title, normalize=normalize, hide_zeros=hide_zeros,
                                         x_tick_rotation=x_tick_rotation, ax=ax, figsize=figsize,
                                         title_fontsize=title_fontsize, text_fontsize=text_fontsize)
 

--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -22,8 +22,8 @@ from sklearn.metrics import silhouette_score
 from sklearn.metrics import silhouette_samples
 
 
-def plot_confusion_matrix(y_true, y_pred, labels=None, title=None, normalize=False, x_tick_rotation=0,
-                          ax=None, figsize=None, title_fontsize="large", text_fontsize="medium"):
+def plot_confusion_matrix(y_true, y_pred, labels=None, title=None, normalize=False, hide_zeros=False,
+                          x_tick_rotation=0, ax=None, figsize=None, title_fontsize="large", text_fontsize="medium"):
     """Generates confusion matrix plot for a given set of ground truth labels and classifier predictions.
 
     Args:
@@ -42,6 +42,9 @@ def plot_confusion_matrix(y_true, y_pred, labels=None, title=None, normalize=Fal
             `normalize` is True. Else, defaults to "Normalized Confusion Matrix.
 
         normalize (bool, optional): If True, normalizes the confusion matrix before plotting.
+            Defaults to False.
+
+        hide_zeros (bool, optional): If True, does not plot cells containing a value of zero.
             Defaults to False.
 
         x_tick_rotation (int, optional): Rotates x-axis tick labels by the specified angle. This is
@@ -105,11 +108,12 @@ def plot_confusion_matrix(y_true, y_pred, labels=None, title=None, normalize=Fal
 
     thresh = cm.max() / 2.
     for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
-        ax.text(j, i, cm[i, j],
-                horizontalalignment="center",
-                verticalalignment="center",
-                fontsize=text_fontsize,
-                color="white" if cm[i, j] > thresh else "black")
+        if not (hide_zeros and cm[i, j] == 0):
+            ax.text(j, i, cm[i, j],
+                    horizontalalignment="center",
+                    verticalalignment="center",
+                    fontsize=text_fontsize,
+                    color="white" if cm[i, j] > thresh else "black")
 
     ax.set_ylabel('True label', fontsize=text_fontsize)
     ax.set_xlabel('Predicted label', fontsize=text_fontsize)


### PR DESCRIPTION
Add an optional parameter to the plot_confusion_matrix function to allow the hiding of zero values in the matrix in order to make the plot easier to read in cases where there are many zero values.

Here is what a confusion matrix looks like normally (`hide_zeros = False`)

![scikit_plot_04](https://user-images.githubusercontent.com/4276196/27997388-2e074568-64c5-11e7-9bc7-a9656a191b5a.png)

Here is the same confusion matrix with zeros hidden (`hide_zeros = True`)

![scikit_plot_06](https://user-images.githubusercontent.com/4276196/27997398-4bdba0ca-64c5-11e7-98c3-2ec9ad371bb9.png)