### PR TITLE
Improve handling of unbalanced confusion matrices

### DIFF
--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -53,9 +53,10 @@ def classifier_factory(clf):
     return clf
 
 
-def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, hide_zeros=False,
-                          x_tick_rotation=0, do_cv=True, cv=None, shuffle=True, random_state=None,
-                          ax=None, figsize=None, title_fontsize="large", text_fontsize="medium"):
+def plot_confusion_matrix(clf, X, y, labels=None, true_labels=None, pred_labels=None,
+                          title=None, normalize=False, hide_zeros=False, x_tick_rotation=0,
+                          do_cv=True, cv=None, shuffle=True, random_state=None, ax=None,
+                          figsize=None, title_fontsize="large", text_fontsize="medium"):
     """Generates the confusion matrix for a given classifier and dataset.
 
     Args:
@@ -72,6 +73,12 @@ def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, h
             index the matrix. This may be used to reorder or select a subset of labels.
             If none is given, those that appear at least once in ``y`` are used in sorted order.
             (new in v0.2.5)
+
+        true_labels (array-like, optional): The true labels to display.
+            If none is given, then all of the labels are used.
+
+        pred_labels (array-like, optional): The predicted labels to display.
+            If none is given, then all of the labels are used.
 
         title (string, optional): Title of the generated plot. Defaults to "Confusion Matrix" if
             `normalize` is True. Else, defaults to "Normalized Confusion Matrix.
@@ -164,6 +171,7 @@ def plot_confusion_matrix(clf, X, y, labels=None, title=None, normalize=False, h
         y_true = np.concatenate(trues_list)
 
     ax = plotters.plot_confusion_matrix(y_true=y_true, y_pred=y_pred, labels=labels,
+                                        true_labels=true_labels, pred_labels=pred_labels,
                                         title=title, normalize=normalize, hide_zeros=hide_zeros,
                                         x_tick_rotation=x_tick_rotation, ax=ax, figsize=figsize,
                                         title_fontsize=title_fontsize, text_fontsize=text_fontsize)

--- a/scikitplot/tests/test_classifiers.py
+++ b/scikitplot/tests/test_classifiers.py
@@ -178,6 +178,17 @@ class TestPlotConfusionMatrix(unittest.TestCase):
         scikitplot.classifier_factory(clf)
         ax = clf.plot_confusion_matrix(self.X, self.y, labels=[0, 1, 2])
 
+    def test_true_pred_labels(self):
+        np.random.seed(0)
+        clf = LogisticRegression()
+        scikitplot.classifier_factory(clf)
+
+        true_labels = [0, 1]
+        pred_labels = [0, 2]
+
+        ax = clf.plot_confusion_matrix(self.X, self.y, true_labels=true_labels,
+                pred_labels=pred_labels)
+
     def test_do_cv(self):
         np.random.seed(0)
         clf = LogisticRegression()

--- a/scikitplot/tests/test_plotters.py
+++ b/scikitplot/tests/test_plotters.py
@@ -65,5 +65,98 @@ class TestPlotPCA2DProjection(unittest.TestCase):
         assert ax is out_ax
 
 
+class TestValidateLabels(unittest.TestCase):
+
+    def test_valid_equal(self):
+        known_labels = ["A", "B", "C"]
+        passed_labels = ["A", "B", "C"]
+        arg_name = "true_labels"
+
+        actual = skplt.validate_labels(known_labels, passed_labels, arg_name)
+        self.assertEqual(actual, None)
+
+    def test_valid_subset(self):
+        known_labels = ["A", "B", "C"]
+        passed_labels = ["A", "B"]
+        arg_name = "true_labels"
+
+        actual = skplt.validate_labels(known_labels, passed_labels, arg_name)
+        self.assertEqual(actual, None)
+
+    def test_invalid_one_duplicate(self):
+        known_labels = ["A", "B", "C"]
+        passed_labels = ["A", "B", "B"]
+        arg_name = "true_labels"
+
+        with self.assertRaises(ValueError) as context:
+            skplt.validate_labels(known_labels, passed_labels, arg_name)
+
+        msg = "The following duplicate labels were passed into true_labels: B"
+        self.assertEqual(msg, str(context.exception))
+
+    def test_invalid_two_duplicates(self):
+        known_labels = ["A", "B", "C"]
+        passed_labels = ["A", "B", "A", "B"]
+        arg_name = "true_labels"
+
+        with self.assertRaises(ValueError) as context:
+            skplt.validate_labels(known_labels, passed_labels, arg_name)
+
+        msg = "The following duplicate labels were passed into true_labels: A, B"
+        self.assertEqual(msg, str(context.exception))
+
+    def test_invalid_one_missing(self):
+        known_labels = ["A", "B", "C"]
+        passed_labels = ["A", "B", "D"]
+        arg_name = "true_labels"
+
+        with self.assertRaises(ValueError) as context:
+            skplt.validate_labels(known_labels, passed_labels, arg_name)
+
+        msg = "The following labels were passed into true_labels, but were not found in labels: D"
+        self.assertEqual(msg, str(context.exception))
+
+    def test_invalid_two_missing(self):
+        known_labels = ["A", "B", "C"]
+        passed_labels = ["A", "E", "B", "D"]
+        arg_name = "true_labels"
+
+        with self.assertRaises(ValueError) as context:
+            skplt.validate_labels(known_labels, passed_labels, arg_name)
+
+        msg = "The following labels were passed into true_labels, but were not found in labels: E, D"
+        self.assertEqual(msg, str(context.exception))
+
+    def test_numerical_labels(self):
+        known_labels = [0, 1, 2]
+        passed_labels = [0, 2]
+        arg_name = "true_labels"
+
+        actual = skplt.validate_labels(known_labels, passed_labels, arg_name)
+        self.assertEqual(actual, None)
+
+    def test_invalid_duplicate_numerical_labels(self):
+        known_labels = [0, 1, 2]
+        passed_labels = [0, 2, 2]
+        arg_name = "true_labels"
+
+        with self.assertRaises(ValueError) as context:
+            skplt.validate_labels(known_labels, passed_labels, arg_name)
+
+        msg = "The following duplicate labels were passed into true_labels: 2"
+        self.assertEqual(msg, str(context.exception))
+
+    def test_invalid_missing_numerical_labels(self):
+        known_labels = [0, 1, 2]
+        passed_labels = [0, 2, 3]
+        arg_name = "true_labels"
+
+        with self.assertRaises(ValueError) as context:
+            skplt.validate_labels(known_labels, passed_labels, arg_name)
+
+        msg = "The following labels were passed into true_labels, but were not found in labels: 3"
+        self.assertEqual(msg, str(context.exception))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Here I have made a few changes that make it easier to plot confusion matrices where the true and predicted sets of labels are not the same. This is a case that can occur when doing something like applying "new" categories to a dataset with an older set of categories.

The changes included are the following:

Fix an issue with nan values showing up when unbalanced confusion matrices are normalized. Where rows with zero entries would sum to zero and then divide by zero when normalizing each cell.

Add options to limit the labels displayed on the true and predicted axes, as with unbalanced confusion matrices some of the labels can be only in the set of true labels or only in the set of predicted labels.

You can see the effect of the new options here:

```
import numpy as np
import matplotlib.pyplot as plt
import scikitplot as sciplt

y_true = np.array(["A", "A", "B", "B", "B", "C", "D"])
y_pred = np.array(["A", "A", "Ba", "Bb", "Ba", "C", "D"])

print(y_true.shape)
print(y_pred.shape)

true_labels = np.unique(y_true)
pred_labels = np.unique(y_pred)

labels = np.sort(np.unique(np.concatenate([true_labels, pred_labels])))

true_label_indexes = np.where(np.isin(labels, true_labels))
pred_label_indexes = np.where(np.isin(labels, pred_labels))

sciplt.plotters.plot_confusion_matrix(y_true, y_pred, hide_zeros=True, normalize=True, true_label_indexes=true_label_indexes, pred_label_indexes=pred_label_indexes, labels=labels)
plt.show()
```

![figure_1](https://user-images.githubusercontent.com/4276196/28844521-be191a04-76b9-11e7-9cf9-249397258fcb.png)