### PR TITLE
Change spectral colormap to nipy_spectral

### DIFF
--- a/scikitplot/classifiers.py
+++ b/scikitplot/classifiers.py
@@ -222,7 +222,7 @@ def plot_confusion_matrix_with_cv(clf, X, y, labels=None, true_labels=None,
 def plot_roc_curve_with_cv(clf, X, y, title='ROC Curves', do_cv=True,
                            cv=None, shuffle=True, random_state=None,
                            curves=('micro', 'macro', 'each_class'),
-                           ax=None, figsize=None, cmap='spectral',
+                           ax=None, figsize=None, cmap='nipy_spectral',
                            title_fontsize="large", text_fontsize="medium"):
     """Generates the ROC curves for a given classifier and dataset.
 
@@ -473,7 +473,7 @@ def plot_precision_recall_curve_with_cv(clf, X, y,
                                         random_state=None,
                                         curves=('micro', 'each_class'),
                                         ax=None, figsize=None,
-                                        cmap='spectral',
+                                        cmap='nipy_spectral',
                                         title_fontsize="large",
                                         text_fontsize="medium"):
     """Generates the Precision-Recall curve for a given classifier and dataset.

--- a/scikitplot/metrics.py
+++ b/scikitplot/metrics.py
@@ -175,7 +175,7 @@ def plot_confusion_matrix(y_true, y_pred, labels=None, true_labels=None,
 
 def plot_roc_curve(y_true, y_probas, title='ROC Curves',
                    curves=('micro', 'macro', 'each_class'),
-                   ax=None, figsize=None, cmap='spectral',
+                   ax=None, figsize=None, cmap='nipy_spectral',
                    title_fontsize="large", text_fontsize="medium"):
     """Generates the ROC curves from labels and predicted scores/probabilities
 
@@ -408,7 +408,7 @@ def plot_ks_statistic(y_true, y_probas, title='KS Statistic Plot',
 def plot_precision_recall_curve(y_true, y_probas,
                                 title='Precision-Recall Curve',
                                 curves=('micro', 'each_class'), ax=None,
-                                figsize=None, cmap='spectral',
+                                figsize=None, cmap='nipy_spectral',
                                 title_fontsize="large",
                                 text_fontsize="medium"):
     """Generates the Precision Recall Curve from labels and probabilities
@@ -532,7 +532,7 @@ def plot_precision_recall_curve(y_true, y_probas,
 
 def plot_silhouette(X, cluster_labels, title='Silhouette Analysis',
                     metric='euclidean', copy=True, ax=None, figsize=None,
-                    cmap='spectral', title_fontsize="large",
+                    cmap='nipy_spectral', title_fontsize="large",
                     text_fontsize="medium"):
     """Plots silhouette analysis of clusters provided.
 
@@ -650,7 +650,7 @@ def plot_silhouette(X, cluster_labels, title='Silhouette Analysis',
 
 def plot_calibration_curve(y_true, probas_list, clf_names=None, n_bins=10,
                            title='Calibration plots (Reliability Curves)',
-                           ax=None, figsize=None, cmap='spectral',
+                           ax=None, figsize=None, cmap='nipy_spectral',
                            title_fontsize="large", text_fontsize="medium"):
     """Plots calibration curves for a set of classifier probability estimates.
 

--- a/scikitplot/plotters.py
+++ b/scikitplot/plotters.py
@@ -185,7 +185,7 @@ def plot_confusion_matrix(y_true, y_pred, labels=None, true_labels=None,
             'scikitplot.metrics.plot_roc_curve instead.')
 def plot_roc_curve(y_true, y_probas, title='ROC Curves',
                    curves=('micro', 'macro', 'each_class'),
-                   ax=None, figsize=None, cmap='spectral',
+                   ax=None, figsize=None, cmap='nipy_spectral',
                    title_fontsize="large", text_fontsize="medium"):
     """Generates the ROC curves from labels and predicted scores/probabilities
 
@@ -422,7 +422,7 @@ def plot_ks_statistic(y_true, y_probas, title='KS Statistic Plot',
 def plot_precision_recall_curve(y_true, y_probas,
                                 title='Precision-Recall Curve',
                                 curves=('micro', 'each_class'), ax=None,
-                                figsize=None, cmap='spectral',
+                                figsize=None, cmap='nipy_spectral',
                                 title_fontsize="large",
                                 text_fontsize="medium"):
     """Generates the Precision Recall Curve from labels and probabilities
@@ -773,7 +773,7 @@ def plot_learning_curve(clf, X, y, title='Learning Curve', cv=None,
 @deprecated('This will be removed in v0.4.0. Please use '
             'scikitplot.metrics.plot_silhouette instead.')
 def plot_silhouette(clf, X, title='Silhouette Analysis', metric='euclidean',
-                    copy=True, ax=None, figsize=None, cmap='spectral',
+                    copy=True, ax=None, figsize=None, cmap='nipy_spectral',
                     title_fontsize="large", text_fontsize="medium"):
     """Plots silhouette analysis of clusters using fit_predict.
 

--- a/scikitplot/tests/test_classifiers.py
+++ b/scikitplot/tests/test_classifiers.py
@@ -193,8 +193,8 @@ class TestPlotConfusionMatrix(unittest.TestCase):
         np.random.seed(0)
         clf = LogisticRegression()
         scikitplot.classifier_factory(clf)
-        ax = clf.plot_confusion_matrix(self.X, self.y, cmap='spectral')
-        ax = clf.plot_confusion_matrix(self.X, self.y, cmap=plt.cm.spectral)
+        ax = clf.plot_confusion_matrix(self.X, self.y, cmap='nipy_spectral')
+        ax = clf.plot_confusion_matrix(self.X, self.y, cmap=plt.cm.nipy_spectral)
 
     def test_do_cv(self):
         np.random.seed(0)
@@ -282,8 +282,8 @@ class TestPlotROCCurve(unittest.TestCase):
         np.random.seed(0)
         clf = LogisticRegression()
         scikitplot.classifier_factory(clf)
-        ax = clf.plot_roc_curve(self.X, self.y, cmap='spectral')
-        ax = clf.plot_roc_curve(self.X, self.y, cmap=plt.cm.spectral)
+        ax = clf.plot_roc_curve(self.X, self.y, cmap='nipy_spectral')
+        ax = clf.plot_roc_curve(self.X, self.y, cmap=plt.cm.nipy_spectral)
 
     def test_curve_diffs(self):
         np.random.seed(0)
@@ -435,8 +435,8 @@ class TestPlotPrecisionRecall(unittest.TestCase):
         np.random.seed(0)
         clf = LogisticRegression()
         scikitplot.classifier_factory(clf)
-        ax = clf.plot_precision_recall_curve(self.X, self.y, cmap='spectral')
-        ax = clf.plot_precision_recall_curve(self.X, self.y, cmap=plt.cm.spectral)
+        ax = clf.plot_precision_recall_curve(self.X, self.y, cmap='nipy_spectral')
+        ax = clf.plot_precision_recall_curve(self.X, self.y, cmap=plt.cm.nipy_spectral)
 
     def test_invalid_curve_arg(self):
         np.random.seed(0)

--- a/scikitplot/tests/test_metrics.py
+++ b/scikitplot/tests/test_metrics.py
@@ -73,8 +73,8 @@ class TestPlotConfusionMatrix(unittest.TestCase):
         clf = LogisticRegression()
         clf.fit(self.X, self.y)
         preds = clf.predict(self.X)
-        plot_confusion_matrix(self.y, preds, cmap='spectral')
-        plot_confusion_matrix(self.y, preds, cmap=plt.cm.spectral)
+        plot_confusion_matrix(self.y, preds, cmap='nipy_spectral')
+        plot_confusion_matrix(self.y, preds, cmap=plt.cm.nipy_spectral)
 
     def test_ax(self):
         np.random.seed(0)
@@ -126,8 +126,8 @@ class TestPlotROCCurve(unittest.TestCase):
         clf = LogisticRegression()
         clf.fit(self.X, self.y)
         probas = clf.predict_proba(self.X)
-        plot_roc_curve(self.y, probas, cmap='spectral')
-        plot_roc_curve(self.y, probas, cmap=plt.cm.spectral)
+        plot_roc_curve(self.y, probas, cmap='nipy_spectral')
+        plot_roc_curve(self.y, probas, cmap=plt.cm.nipy_spectral)
 
     def test_curve_diffs(self):
         np.random.seed(0)
@@ -239,8 +239,8 @@ class TestPlotPrecisionRecall(unittest.TestCase):
         clf = LogisticRegression()
         clf.fit(self.X, self.y)
         probas = clf.predict_proba(self.X)
-        plot_precision_recall_curve(self.y, probas, cmap='spectral')
-        plot_precision_recall_curve(self.y, probas, cmap=plt.cm.spectral)
+        plot_precision_recall_curve(self.y, probas, cmap='nipy_spectral')
+        plot_precision_recall_curve(self.y, probas, cmap=plt.cm.nipy_spectral)
 
     def test_invalid_curve_arg(self):
         np.random.seed(0)


### PR DESCRIPTION
Change deprecated 'spectral' colormap to current 'nipy_spectral' in all plotting functions. Tests pass, warnings for colormap is gone.