### PR TITLE
add hide_counts parameter to plot_confusion_matrix()

### DIFF
--- a/scikitplot/metrics.py
+++ b/scikitplot/metrics.py
@@ -32,7 +32,7 @@ from scikitplot.helpers import cumulative_gain_curve
 
 def plot_confusion_matrix(y_true, y_pred, labels=None, true_labels=None,
                           pred_labels=None, title=None, normalize=False,
-                          hide_zeros=False, x_tick_rotation=0, ax=None,
+                          hide_zeros=False, hide_counts=False, x_tick_rotation=0, ax=None,
                           figsize=None, cmap='Blues', title_fontsize="large",
                           text_fontsize="medium"):
     """Generates confusion matrix plot from predictions and true labels
@@ -64,6 +64,9 @@ def plot_confusion_matrix(y_true, y_pred, labels=None, true_labels=None,
 
         hide_zeros (bool, optional): If True, does not plot cells containing a
             value of zero. Defaults to False.
+
+        hide_counts (bool, optional): If True, doe not overlay counts.
+            Defaults to False.
 
         x_tick_rotation (int, optional): Rotates x-axis tick labels by the
             specified angle. This is useful in cases where there are numerous
@@ -160,13 +163,15 @@ def plot_confusion_matrix(y_true, y_pred, labels=None, true_labels=None,
     ax.set_yticklabels(true_classes, fontsize=text_fontsize)
 
     thresh = cm.max() / 2.
-    for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
-        if not (hide_zeros and cm[i, j] == 0):
-            ax.text(j, i, cm[i, j],
-                    horizontalalignment="center",
-                    verticalalignment="center",
-                    fontsize=text_fontsize,
-                    color="white" if cm[i, j] > thresh else "black")
+
+    if not hide_counts:
+        for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
+            if not (hide_zeros and cm[i, j] == 0):
+                ax.text(j, i, cm[i, j],
+                        horizontalalignment="center",
+                        verticalalignment="center",
+                        fontsize=text_fontsize,
+                        color="white" if cm[i, j] > thresh else "black")
 
     ax.set_ylabel('True label', fontsize=text_fontsize)
     ax.set_xlabel('Predicted label', fontsize=text_fontsize)

--- a/scikitplot/tests/test_metrics.py
+++ b/scikitplot/tests/test_metrics.py
@@ -59,6 +59,13 @@ class TestPlotConfusionMatrix(unittest.TestCase):
         preds = clf.predict(self.X)
         plot_confusion_matrix(self.y, preds, labels=[0, 1, 2])
 
+    def test_hide_counts(self):
+        np.random.seed(0)
+        clf = LogisticRegression()
+        clf.fit(self.X, self.y)
+        preds = clf.predict(self.X)
+        plot_confusion_matrix(self.y, preds, hide_counts=True)
+
     def test_true_pred_labels(self):
         np.random.seed(0)
         clf = LogisticRegression()


### PR DESCRIPTION
This pull request adds a hide_counts parameter to the plot_confusion_matrix() function to allow for disabling of the overlaying of count text on the plot.

Sample code for testing:

```
import matplotlib.pyplot as plt
import scikitplot as skplt
from sklearn.datasets import load_digits
from sklearn.ensemble import RandomForestClassifier
from sklearn.model_selection import cross_val_predict

X, y = load_digits(return_X_y=True)
random_forest_clf = RandomForestClassifier(n_estimators=5, max_depth=5, random_state=1)
predictions = cross_val_predict(random_forest_clf, X, y)

skplt.metrics.plot_confusion_matrix(y, predictions, hide_counts=True)
plt.show()
```